### PR TITLE
Minor fixes to sponsorship packet stuff 

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -15,6 +15,8 @@ from emails.sending import send_email_now
 from hackathons.models import Hackathon, Sponsorship, Lead
 from hackathons.views.sponsorships import combine_lead_and_contacts
 
+from shared import packet
+
 from .models import Email
 from .forms import ComposeFromContactsForm, ComposeFromCompanyForm, ComposeFromIndustryForm, EmailChangeTypeForm
 
@@ -159,7 +161,7 @@ def send_message(request, h_pk, pk):
             message = email.render_body(contact)
             packet_file = None
             if email.attach_packet:
-                packet_file = os.path.join(settings.PROJECT_ROOT, 'static', settings.SPONSORSHIP_PACKET_FILE)
+                packet_file = packet.get_packet_file_path()
 
             print(f"SENDING: {email.subject} TO: {contact} ({contact.email}) ATTACHMENT: {packet_file}")
             print(send_email_now(email.subject, message, contact.email, packet_file))

--- a/website/settings.py
+++ b/website/settings.py
@@ -55,7 +55,7 @@ SPONSORSHIP_PACKET_URL = str_environ("SPONSORSHIP_PACKET_URL")
 # The local name of the sponsorship packet, to be stored in the website/static
 # folder. If this file exists, it will be used. Otherwise, it will be
 # redownloaded from SPONSORSHIP_PACKET_URL.
-SPONSORSHIP_PACKET_FILE = str_environ("SPONSORSHIP_PACKET_FILE")
+SPONSORSHIP_PACKET_FILE = str_environ("SPONSORSHIP_PACKET_FILE", "sponsorship.pdf")
 
 if not PRODUCTION and 'DEBUG' not in os.environ:
     DEBUG = True


### PR DESCRIPTION
Looking to redeploy this as we begin to ramp up for our next hackathon, I realize I never submitted these fixes upstream, so I'm doing that now.

Firstly, it seems there was code added to `shared/packet.py` to handle getting the packet file path, but it wasn't used when attaching the packet to the email.

Second, I set a default value for the location of the sponsorship packet in `website/static` so that I didn't have to set this when I was just getting the packet from a URL. This allows for easier first-time configuration, but also leaves the current level of configurability if desired.