### PR TITLE
Add ASSIGNED status to Sponsorships

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -100,7 +100,7 @@ def gen_sponsorship_chart(sponsorships, hackathon):
     for sp in sponsorships:
         if sp.status in [Sponsorship.CONFIRMED, Sponsorship.PAID]:
             confirmed_count += 1
-        elif sp.status in [Sponsorship.CONTACTED, Sponsorship.RESPONDED]:
+        elif sp.status in [Sponsorship.ASSIGNED, Sponsorship.CONTACTED, Sponsorship.RESPONDED]:
             progress_count += 1
         elif sp.status in [Sponsorship.DENIED, Sponsorship.GHOSTED]:
             dead_count += 1

--- a/hackathons/models.py
+++ b/hackathons/models.py
@@ -61,6 +61,7 @@ class Perk(models.Model):
 
 
 class Sponsorship(models.Model):
+    ASSIGNED = "assigned"
     CONTACTED = "contacted"
     RESPONDED = "responded"
     CONFIRMED = "confirmed"
@@ -68,6 +69,7 @@ class Sponsorship(models.Model):
     GHOSTED = "ghosted"
     PAID = "paid"
     STATUSES = (
+        (ASSIGNED, "Assigned"),
         (CONTACTED, "Contacted"),
         (RESPONDED, "Responded"),
         (CONFIRMED, "Confirmed"),

--- a/hackathons/templates/cards/sponsorship_status.html
+++ b/hackathons/templates/cards/sponsorship_status.html
@@ -1,6 +1,8 @@
 <span style="white-space: nowrap">
 {% if not sponsorship %}
     <span class="status-icon bg-gray-dark"></span> Uncontacted
+{% elif sponsorship.status == 'assigned' %}
+    <span class="status-icon bg-cyan"></span> Assigned
 {% elif sponsorship.status == 'contacted' %}
     <span class="status-icon bg-orange"></span> Contacted
 {% elif sponsorship.status == 'responded' %}

--- a/hackathons/templates/cards/sponsorship_table.html
+++ b/hackathons/templates/cards/sponsorship_table.html
@@ -104,7 +104,7 @@
                     <td>
                     {% if faked %}
                         <a class="tag tag-red float-right" href="{% url 'hackathons:sponsorships:new' h.pk %}?company={{ s.company.pk }}">
-                            Mark Contacted
+                            Start Tracking
                         </a>
                     {% else %}
                         <a class="icon" href="{% url 'hackathons:sponsorships:edit' h.pk s.company.pk %}">

--- a/hackathons/templates/sponsorship_detail.html
+++ b/hackathons/templates/sponsorship_detail.html
@@ -19,7 +19,7 @@
         {% else %}
             <div class="col text-right h2">
                 <a class="button" href="{% url 'hackathons:sponsorships:new' h.pk %}?company={{ company.pk }}">
-                    <button class="btn btn-primary ml-auto">Mark Contacted</button>
+                    <button class="btn btn-primary ml-auto">Start Tracking</button>
                 </a>
             </div>
         {% endif %}
@@ -34,7 +34,7 @@
                 <div class="col-sm-8 text-center" style="font-size: 14px">
                     <i class="fe fe-alert-triangle" style="color: red"></i>
                     <b style="font-size: 16px; color: red">This company has not been contacted for the current hackathon.</b><br />
-                    Press "Mark Contacted" to begin tracking this company as a potential sponsor.
+                    Press "Start Tracking" to begin tracking this company as a potential sponsor.
                 </div>
             {% elif no_contacted_employees %}
                 <div class="col-sm-8 text-center" style="font-size: 14px">

--- a/hackathons/templates/sponsorships_summary.html
+++ b/hackathons/templates/sponsorships_summary.html
@@ -55,7 +55,7 @@ table.small-th th {
                     </a>
                     {% if faked %}
                         <a class="tag tag-red" style="position: absolute; top: 15px; right: 15px" href="{% url 'hackathons:sponsorships:new' h.pk %}?company={{ s.company.pk }}">
-                            Mark Contacted
+                            Start Tracking
                         </a>
                     {% else %}
                         <a class="icon" href="{% url 'hackathons:sponsorships:edit' h.pk s.company.pk %}" style="position: absolute; top: 15px; right: 15px">

--- a/hackathons/views/sponsorships.py
+++ b/hackathons/views/sponsorships.py
@@ -80,7 +80,7 @@ def sponsorships_show_context(request, h_pk):
         return [Sponsorship(pk=0, company=c, tier=None, contribution=0) for c in company]
     
     confirmed = sponsorship_wrapper("confirmed", [Sponsorship.CONFIRMED, Sponsorship.PAID])
-    in_progress = sponsorship_wrapper("in_progress", [Sponsorship.CONTACTED, Sponsorship.RESPONDED])
+    in_progress = sponsorship_wrapper("in_progress", [Sponsorship.ASSIGNED, Sponsorship.CONTACTED, Sponsorship.RESPONDED])
     dead = sponsorship_wrapper("dead", [Sponsorship.GHOSTED, Sponsorship.DENIED])
     uncontacted = company_wrapper("uncontacted")
 


### PR DESCRIPTION
The Cypher team started dipping our toes into Hackerforce and we found ourselves wanting to assign sponsorships to hackers without necessarily marking them as contacted. For example, I know that I'll be contacting a few companies eventually, but as it's the holidays I can't contact them immediately. However, I'd still like to create a record of my being responsible for them, so the rest of the team can see that someone's covering them.

Changes:

* Added a new `Sponsorship.ASSIGNED` status.
* Updated various views and templates to reflect the existence of the new status. (`ASSIGNED` is counted as an "in progress" status. Its assigned color is cyan 🙂)
* Changed the `Mark Contacted` button for sponsors (but not for leads) to say `Start Tracking` - which is more descriptive of the action now that you can track a company without marking it as contacted.