### PR TITLE
shared/packet: Remove print when get_packet is called

### DIFF
--- a/shared/packet.py
+++ b/shared/packet.py
@@ -8,8 +8,6 @@ def get_packet_file_path():
 def fetch_packet():
     if settings.SPONSORSHIP_PACKET_FILE and settings.SPONSORSHIP_PACKET_URL:
         if not os.path.exists(get_packet_file_path()):
-            print("Downloading the sponsorship packet to: {}", get_packet_file_path())
-
             r = requests.get(settings.SPONSORSHIP_PACKET_URL, stream=True)
             if r.status_code == 200:
                 with open(get_packet_file_path(), 'wb') as f:


### PR DESCRIPTION
Otherwise this print ends up as part of the dump file and has to be removed when restoring.